### PR TITLE
refactor: have queries return a Response which is null or a Table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ file(GLOB_RECURSE TEST_SRCS ${PROJECT_SOURCE_DIR}/test/*.c*)
 add_executable(Database src/main.cpp ${SRCS})
 add_executable(Test ${TEST_SRCS} ${SRCS})
 
+add_compile_definitions(Test ERRORS_AS_WARNINGS)
+
 find_package(Catch2 REQUIRED)
 target_link_libraries(Test Catch2::Catch2)
 include(CTest)

--- a/src/DBMS/Cell/Cell.h
+++ b/src/DBMS/Cell/Cell.h
@@ -9,7 +9,7 @@
 
 using Cell = std::variant <std::monostate, bool, short, long, std::string>;
 
-enum CellTypes {
+enum CellType {
     UNARY,
     BINARY,
     SHORT,

--- a/src/DBMS/DBMS.cpp
+++ b/src/DBMS/DBMS.cpp
@@ -1,6 +1,6 @@
 #include "DBMS.h"
 
-kj::Own <Table const> DBMS::evalQuery (std::string const & rawQuery) {
+Response DBMS::evalQuery (std::string const & rawQuery) {
     kj::Own <Query> procQuery = Parser::parseQuery (rawQuery);
     switch (procQuery->targetType) {
         case Database::Target::Type::VOID:
@@ -15,7 +15,7 @@ kj::Own <Table const> DBMS::evalQuery (std::string const & rawQuery) {
     return kj::heap <Table const> (std::vector <std::string>({"a"}));
 }
 
-kj::Own <Table const> DBMS::evalTableQuery (kj::Own <Query> const & query) {
+Response DBMS::evalTableQuery (kj::Own <Query> const & query) {
     if (query->actionOnTarget == Database::Target::Action::CREATE) {
         auto const & spec = std::get <Database::Target::Table::Specification> (query->spec);
         std::vector <std::string> header;
@@ -33,8 +33,21 @@ kj::Own <Table const> DBMS::evalTableQuery (kj::Own <Query> const & query) {
     return testTable;
 }
 
-kj::Own <Table const> DBMS::evalUserQuery (kj::Own <Query> const & query) {
+Response DBMS::evalUserQuery (kj::Own <Query> const & query) {
     return kj::heap <Table> (std::vector <std::string> { "USER", "PERMISSION" });
+}
+
+std::ostream & operator << (std::ostream & os, Response const & response) {
+    switch (response.index()) {
+        case ResponseType::VOID:
+            break;
+        case ResponseType::TABLE:
+            os << * std::get <kj::Own <Table const>> (response);
+            break;
+        default:
+            LOG (FATAL) << "Response has gone insane";
+    }
+    return os;
 }
 
 /* Copyright (C) 2020 Aaron Alef & Felix Bachstein */

--- a/src/DBMS/DBMS.h
+++ b/src/DBMS/DBMS.h
@@ -7,13 +7,21 @@
 
 #include <memory>
 #include <kj/async.h>
+#include <variant>
+
+using Response = std::variant <std::monostate, kj::Own <Table const>>;
+enum ResponseType {
+    VOID,
+    TABLE
+};
+std::ostream & operator << (std::ostream & os, Response const & response);
 
 struct DBMS {
     DBMS() = delete;
 
-    static kj::Own <Table const> evalQuery (std::string const & rawQuery);
-    static kj::Own <Table const> evalTableQuery (kj::Own <Query> const & query);
-    static kj::Own <Table const> evalUserQuery (kj::Own <Query> const & query);
+    static Response evalQuery (std::string const & rawQuery);
+    static Response evalTableQuery (kj::Own <Query> const & query);
+    static Response evalUserQuery (kj::Own <Query> const & query);
 };
 
 

--- a/src/Language/Parser/ParseTree/ParseTree.cpp
+++ b/src/Language/Parser/ParseTree/ParseTree.cpp
@@ -32,13 +32,25 @@ std::ostream & ParseTree::operator << (std::ostream & os) const {
     return (os << this->str());
 }
 
-std::string ParseTree::str (bool nl) const{
-    bool isInner = parent && parent->tryGetInner();
-    std::string str (getTokenName());
-    if (inner) str += (isInner ? '[' : '(') + inner->str() + (isInner ? ']' : ')');
-    if (next)  str += (isInner ? ',' : '.') + next->str();
-    if (nl && !parent) str += '\n';
-    return str;
+std::string const & ParseTree::str (std::string & s, bool pp) const {
+    if (pp && parent) return parent->str (s, true);
+    bool isParam = parent && parent->tryGetInner ();
+    s += token;
+    if (inner) {
+        s += (isParam ? type == Token::KV_PAIR ? '{' : '[' : '(');
+        inner->str (s, false);
+        s += (isParam ? type == Token::KV_PAIR ? '}' : ']' : ')');
+    }
+    if (next) {
+        s += (isParam ? type == Token::KEY ? ',' : ':' : '.');
+        next->str (s, false);
+    }
+    return s;
+}
+
+std::string ParseTree::str (bool pp) const {
+    std::string string;
+    return str (string, pp);
 }
 
 char ParseTree::operator [] (int index) const {

--- a/src/Language/Parser/ParseTree/ParseTree.h
+++ b/src/Language/Parser/ParseTree/ParseTree.h
@@ -16,6 +16,8 @@ private:
 
     explicit ParseTree (ParseTree * parent);
 
+    std::string const & str (std::string & str, bool printParents = true) const;
+
 public:
     ParseTree();
     ~ParseTree();
@@ -32,7 +34,7 @@ public:
     [[nodiscard]] Token::Type getParentType() const;
 
     [[nodiscard]] std::string getTokenName() const;
-    [[nodiscard]] std::string str (bool nl = false) const;
+    [[nodiscard]] std::string str (bool printParents = true) const;
 
     std::ostream & operator << (std::ostream & os) const;
     [[nodiscard]] char operator [] (int index) const;

--- a/src/Language/Parser/Parser.cpp
+++ b/src/Language/Parser/Parser.cpp
@@ -139,7 +139,7 @@ kj::Own <Query> Parser::buildQuery (kj::Own <ParseTree> const & pt) {
             LOG_ASSERT (! token->tryGetInner ());
             if (! token->tryGetNext ()) {
                 THROW (std::logic_error (STR +
-                                         "Method on Database '" + structure->database + "' expected; found nothing"));
+                "Method on Database '" + structure->database + "' expected; found nothing"));
             }
             token = token->tryGetNext ();
             switch (token->type) {
@@ -153,28 +153,27 @@ kj::Own <Query> Parser::buildQuery (kj::Own <ParseTree> const & pt) {
                     LOG_ASSERT (! token->tryGetInner ());
                     if (! token->tryGetNext ()) {
                         THROW (std::logic_error (STR +
-                                                 "Method on Target '" + structure->target +
-                                                 "' expected; found nothing"));
+                        "Method on Target '" + structure->target +
+                        "' expected; found nothing"));
                     }
                     token = token->tryGetNext ();
                     if (! token->tryGetInner ()) {
                         THROW (std::logic_error (STR +
-                                                 "Parameters for function call on '" + structure->target +
-                                                 "' expected; found nothing"));
+                        "Parameters for function call on '" + structure->target +"' expected; found nothing"));
                     }
                     switch (structure->targetType) {
                         case Database::Target::TABLE: {
                             auto spec = Database::Target::Table::Specification ();
-                            spec.action = (Database::Target::Table::Action) lookUpEnum (token->getTokenName (),
-                                                                                        Database::Target::Table::ActionStrings);
-                            fillInSpecs (token = token->tryGetInner (), spec);
-                            structure->spec = std::move (Database::Target::Specification (spec));
+                            spec.action = (Database::Target::Table::Action) lookUpEnum (
+                                    token->getTokenName (), Database::Target::Table::ActionStrings);
+//                            fillInSpecs (token = token->tryGetInner (), spec);
+//                            structure->spec = std::move (Database::Target::Specification (spec));
                         } break;
 
                         case Database::Target::USER: {
                             auto spec = Database::Target::User::Specification ();
-                            spec.action = (Database::Target::User::Action) lookUpEnum (token->getTokenName (),
-                                                                                       Database::Target::User::ActionStrings);
+                            spec.action = (Database::Target::User::Action) lookUpEnum (
+                                    token->getTokenName (), Database::Target::User::ActionStrings);
                             fillInSpecs (token = token->tryGetInner (), spec);
                             structure->spec = std::move (Database::Target::Specification (spec));
                         } break;
@@ -277,44 +276,48 @@ inline short Parser::lookUpEnum (std::string const & str, std::vector <std::stri
 
 void Parser::fillInSpecs (ParseTree const * tree, Database::Target::Table::Specification & specs) {
     switch (specs.action) {
-        case Database::Target::Table::READ:
-            if (!(tree->tryGetInner() && tree->tryGetNext() && tree->tryGetNext()->tryGetInner())) {
-                if (!(tree->type == Token::LIST && tree->tryGetNext()->type == Token::LIST)) {
-                    THROW (std::logic_error (STR+
-                    "For SELECT function, expected a list [COLUMN] and a list of maps [{COLUMN : value}] of parameters"));
-                }
-            }
-            fillPairLists (tree, specs.values);
-            fillPairLists (tree, specs.where);
-            break;
-        case Database::Target::Table::INSERT:
-            if (!(tree->tryGetInner())) {
-                if (!(tree->type == Token::LIST)) {
-                    THROW (std::logic_error (STR+
-                    "For INSERT function, expected a list of maps [{COLUMN : value}] as parameter"));
-                }
-            }
-            fillPairLists (tree, specs.where);
-            break;
-        case Database::Target::Table::REMOVE:
-            if (!(tree->tryGetInner())) {
-                if (!(tree->type == Token::LIST)) {
+        case Database::Target::Table::READ: {
+            if (! (tree->tryGetInner () && tree->tryGetNext () && tree->tryGetNext ()->tryGetInner ())) {
+                if (! (tree->type == Token::LIST && tree->tryGetNext ()->type == Token::LIST)) {
                     THROW (std::logic_error (STR +
-                    "For REMOVE function, expected a list of maps [{COLUMN : value}] as parameter"));
-                }
-            }
-            fillPairLists (tree, specs.where);
-            break;
-        case Database::Target::Table::UPDATE:
-            if (!(tree->tryGetInner() && tree->tryGetNext() && tree->tryGetNext()->tryGetInner())) {
-                if (!(tree->type == Token::LIST && tree->tryGetNext()->type == Token::LIST)) {
-                    THROW (std::logic_error (STR+
-                    "For SELECT function, expected a list of maps [{COLUMN : value}] each as values and spec parameters"));
+                                             "For SELECT function, expected a list [COLUMN] and a list of maps [{COLUMN : value}] of parameters"));
                 }
             }
             fillPairLists (tree, specs.values);
             fillPairLists (tree, specs.where);
-            break;
+        } break;
+
+        case Database::Target::Table::INSERT: {
+            if (! (tree->tryGetInner ())) {
+                if (! (tree->type == Token::LIST)) {
+                    THROW (std::logic_error (STR +
+                                             "For INSERT function, expected a list of maps [{COLUMN : value}] as parameter"));
+                }
+            }
+            fillPairLists (tree, specs.where);
+        } break;
+
+        case Database::Target::Table::REMOVE: {
+            if (! (tree->tryGetInner ())) {
+                if (! (tree->type == Token::LIST)) {
+                    THROW (std::logic_error (STR +
+                                             "For REMOVE function, expected a list of maps [{COLUMN : value}] as parameter"));
+                }
+            }
+            fillPairLists (tree, specs.where);
+        } break;
+
+        case Database::Target::Table::UPDATE: {
+            if (! (tree->tryGetInner () && tree->tryGetNext () && tree->tryGetNext ()->tryGetInner ())) {
+                if (! (tree->type == Token::LIST && tree->tryGetNext ()->type == Token::LIST)) {
+                    THROW (std::logic_error (STR +
+                                             "For SELECT function, expected a list of maps [{COLUMN : value}] each as values and spec parameters"));
+                }
+            }
+            fillPairLists (tree, specs.values);
+            fillPairLists (tree, specs.where);
+        } break;
+
         default:
             LOG (FATAL) << "Invalid action detected";
     }

--- a/src/Server/Server.h
+++ b/src/Server/Server.h
@@ -21,7 +21,7 @@ class DatabaseImpl final : public RPCServer::Server {
 public:
     kj::Promise <void> sendQuery (SendQueryContext context) override {
         std::cout << "Server: 'Received Query: " << context.getParams ().getQuery() << "'" << std::endl;
-        auto responseBuilder = Wrapper::wrapResponse (evalQuery (context.getParams().getQuery()));
+        kj::Own <capnp::MallocMessageBuilder> responseBuilder = std::move (Wrapper::wrapResponse (evalQuery (context.getParams().getQuery())));
         context.getResults().setResponse (responseBuilder->template getRoot <RPCServer::Response>().asReader());
         return kj::READY_NOW;
     }
@@ -35,7 +35,7 @@ private:
     Response evalQuery (std::string const & query) const {
         //TODO: make this fool proof
 
-        kj::Own <Table const> result;
+        Response result;
         LOG (INFO) << "Executing the following query: \n'" << query << "'";
         LOG_TIME (result = T::evalQuery (query));
 

--- a/src/Server/Server.h
+++ b/src/Server/Server.h
@@ -21,8 +21,8 @@ class DatabaseImpl final : public RPCServer::Server {
 public:
     kj::Promise <void> sendQuery (SendQueryContext context) override {
         std::cout << "Server: 'Received Query: " << context.getParams ().getQuery() << "'" << std::endl;
-        auto tableBuilder = Wrapper::wrapTable (evalQuery (context.getParams().getQuery()));
-        context.getResults().setTable (tableBuilder->template getRoot <RPCServer::Table>().asReader());
+        auto responseBuilder = Wrapper::wrapResponse (evalQuery (context.getParams().getQuery()));
+        context.getResults().setResponse (responseBuilder->template getRoot <RPCServer::Response>().asReader());
         return kj::READY_NOW;
     }
 
@@ -32,7 +32,7 @@ public:
     }
 
 private:
-    kj::Own <Table const> evalQuery (std::string const & query) const {
+    Response evalQuery (std::string const & query) const {
         //TODO: make this fool proof
 
         kj::Own <Table const> result;

--- a/src/Server/ServerDBMS.capnp
+++ b/src/Server/ServerDBMS.capnp
@@ -22,6 +22,13 @@ interface RPCServer {
         }
     }
 
-    sendQuery @0 (query :Text) -> (table :Table);
+    struct Response {
+        data :union {
+            void @0 :Void;
+            table @1 :Table;
+        }
+    }
+
+    sendQuery @0 (query :Text) -> (response :Response);
     connect @1 () -> ();
 }

--- a/src/Server/Wrapper/Wrapper.cpp
+++ b/src/Server/Wrapper/Wrapper.cpp
@@ -1,12 +1,12 @@
 #include <capnp/message.h>
 #include "Wrapper.h"
 
-kj::Own <capnp::MallocMessageBuilder> const & Wrapper::wrapResponse (Response response) {
+kj::Own <capnp::MallocMessageBuilder> Wrapper::wrapResponse (Response response) {
     switch (response.index()) {
-        case ResponseType::VOID:
-            static kj::Own <capnp::MallocMessageBuilder> responseBuilder = kj::heap <capnp::MallocMessageBuilder>();
-            responseBuilder->initRoot <RPCServer::Response>().initData().setVoid();
-            return responseBuilder;
+        case ResponseType::VOID: {
+            kj::Own <capnp::MallocMessageBuilder> responseBuilder = kj::heap <capnp::MallocMessageBuilder> ();
+            responseBuilder->initRoot <RPCServer::Response> ().initData ().setVoid ();
+            return responseBuilder; }
         case ResponseType::TABLE:
             return std::move (wrapTable (std::get <kj::Own <Table const>> (response)));
         default:

--- a/src/Server/Wrapper/Wrapper.h
+++ b/src/Server/Wrapper/Wrapper.h
@@ -9,7 +9,7 @@
 
 namespace Wrapper {
 
-kj::Own <capnp::MallocMessageBuilder> const & wrapResponse (Response response);
+kj::Own <capnp::MallocMessageBuilder> wrapResponse (Response response);
 Response unwrapResponse (::RPCServer::Response::Reader const & reader);
 
 kj::Own <capnp::MallocMessageBuilder> wrapTable (kj::Own <Table const> const & table);

--- a/src/Server/Wrapper/Wrapper.h
+++ b/src/Server/Wrapper/Wrapper.h
@@ -1,13 +1,18 @@
 #ifndef DATABASE_WRAPPER_H
 #define DATABASE_WRAPPER_H
 
+#include "../../DBMS/DBMS.h"
 #include "../../DBMS/Table/Table.h"
 #include "../generated/ServerDBMS.capnp.h"
 
 #include <capnp/message.h>
 
 namespace Wrapper {
-kj::Own <capnp::MallocMessageBuilder> wrapTable (kj::Own <Table const> table);
+
+kj::Own <capnp::MallocMessageBuilder> const & wrapResponse (Response response);
+Response unwrapResponse (::RPCServer::Response::Reader const & reader);
+
+kj::Own <capnp::MallocMessageBuilder> wrapTable (kj::Own <Table const> const & table);
 kj::Own <Table> unwrapTable (::RPCServer::Table::Reader const & reader);
 
 kj::Own <capnp::MallocMessageBuilder> wrapCell (Cell const & cell);

--- a/src/Server/generated/ServerDBMS.capnp.c++
+++ b/src/Server/generated/ServerDBMS.capnp.c++
@@ -5,7 +5,7 @@
 
 namespace capnp {
 namespace schemas {
-static const ::capnp::_::AlignedData<43> b_cb711ada46b974b8 = {
+static const ::capnp::_::AlignedData<47> b_cb711ada46b974b8 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
     184, 116, 185,  70, 218,  26, 113, 203,
      17,   0,   0,   0,   3,   0,   0,   0,
@@ -13,19 +13,23 @@ static const ::capnp::_::AlignedData<43> b_cb711ada46b974b8 = {
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 218,   0,   0,   0,
-     33,   0,   0,   0,  23,   0,   0,   0,
+     33,   0,   0,   0,  39,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     41,   0,   0,   0, 135,   0,   0,   0,
-    125,   0,   0,   0,   7,   0,   0,   0,
+     57,   0,   0,   0, 135,   0,   0,   0,
+    141,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      83, 101, 114, 118, 101, 114,  68,  66,
      77,  83,  46,  99,  97, 112, 110, 112,
      58,  82,  80,  67,  83, 101, 114, 118,
     101, 114,   0,   0,   0,   0,   0,   0,
-      4,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   1,   0,   1,   0,
     229,  89, 100,  76, 194,  40, 112, 209,
-      1,   0,   0,   0,  50,   0,   0,   0,
+      9,   0,   0,   0,  50,   0,   0,   0,
+    183, 176, 218, 107,  82,  59, 239, 207,
+      5,   0,   0,   0,  74,   0,   0,   0,
      84,  97,  98, 108, 101,   0,   0,   0,
+     82, 101, 115, 112, 111, 110, 115, 101,
+      0,   0,   0,   0,   0,   0,   0,   0,
       8,   0,   0,   0,   3,   0,   5,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
     181, 188, 233, 153,  60, 177,  71, 207,
@@ -60,7 +64,7 @@ static const ::capnp::_::RawSchema* const d_cb711ada46b974b8[] = {
 };
 static const uint16_t m_cb711ada46b974b8[] = {1, 0};
 const ::capnp::_::RawSchema s_cb711ada46b974b8 = {
-  0xcb711ada46b974b8, b_cb711ada46b974b8.words, 43, d_cb711ada46b974b8, m_cb711ada46b974b8,
+  0xcb711ada46b974b8, b_cb711ada46b974b8.words, 47, d_cb711ada46b974b8, m_cb711ada46b974b8,
   4, 2, nullptr, nullptr, nullptr, { &s_cb711ada46b974b8, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
@@ -361,6 +365,111 @@ const ::capnp::_::RawSchema s_aa2ac7c0d0ba789d = {
   1, 5, i_aa2ac7c0d0ba789d, nullptr, nullptr, { &s_aa2ac7c0d0ba789d, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<27> b_cfef3b526bdab0b7 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    183, 176, 218, 107,  82,  59, 239, 207,
+     27,   0,   0,   0,   1,   0,   1,   0,
+    184, 116, 185,  70, 218,  26, 113, 203,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  34,   1,   0,   0,
+     37,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     33,   0,   0,   0,  63,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     83, 101, 114, 118, 101, 114,  68,  66,
+     77,  83,  46,  99,  97, 112, 110, 112,
+     58,  82,  80,  67,  83, 101, 114, 118,
+    101, 114,  46,  82, 101, 115, 112, 111,
+    110, 115, 101,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      4,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+    186,   2, 182,  55, 208, 147, 151, 211,
+     13,   0,   0,   0,  42,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    100,  97, 116,  97,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_cfef3b526bdab0b7 = b_cfef3b526bdab0b7.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_cfef3b526bdab0b7[] = {
+  &s_d39793d037b602ba,
+};
+static const uint16_t m_cfef3b526bdab0b7[] = {0};
+static const uint16_t i_cfef3b526bdab0b7[] = {0};
+const ::capnp::_::RawSchema s_cfef3b526bdab0b7 = {
+  0xcfef3b526bdab0b7, b_cfef3b526bdab0b7.words, 27, d_cfef3b526bdab0b7, m_cfef3b526bdab0b7,
+  1, 1, i_cfef3b526bdab0b7, nullptr, nullptr, { &s_cfef3b526bdab0b7, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<49> b_d39793d037b602ba = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    186,   2, 182,  55, 208, 147, 151, 211,
+     36,   0,   0,   0,   1,   0,   1,   0,
+    183, 176, 218, 107,  82,  59, 239, 207,
+      1,   0,   7,   0,   1,   0,   2,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  74,   1,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     33,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     83, 101, 114, 118, 101, 114,  68,  66,
+     77,  83,  46,  99,  97, 112, 110, 112,
+     58,  82,  80,  67,  83, 101, 114, 118,
+    101, 114,  46,  82, 101, 115, 112, 111,
+    110, 115, 101,  46, 100,  97, 116,  97,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0, 255, 255,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  42,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0, 254, 255,   0,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0,  50,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     40,   0,   0,   0,   3,   0,   1,   0,
+     52,   0,   0,   0,   2,   0,   1,   0,
+    118, 111, 105, 100,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116,  97,  98, 108, 101,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    229,  89, 100,  76, 194,  40, 112, 209,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_d39793d037b602ba = b_d39793d037b602ba.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_d39793d037b602ba[] = {
+  &s_cfef3b526bdab0b7,
+  &s_d17028c24c6459e5,
+};
+static const uint16_t m_d39793d037b602ba[] = {1, 0};
+static const uint16_t i_d39793d037b602ba[] = {0, 1};
+const ::capnp::_::RawSchema s_d39793d037b602ba = {
+  0xd39793d037b602ba, b_d39793d037b602ba.words, 49, d_d39793d037b602ba, m_d39793d037b602ba,
+  2, 2, i_d39793d037b602ba, nullptr, nullptr, { &s_d39793d037b602ba, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<34> b_cf47b13c99e9bcb5 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
     181, 188, 233, 153,  60, 177,  71, 207,
@@ -406,7 +515,7 @@ const ::capnp::_::RawSchema s_cf47b13c99e9bcb5 = {
   0, 1, i_cf47b13c99e9bcb5, nullptr, nullptr, { &s_cf47b13c99e9bcb5, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<34> b_93a6e8640a620cdc = {
+static const ::capnp::_::AlignedData<35> b_93a6e8640a620cdc = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
     220,  12,  98,  10, 100, 232, 166, 147,
      27,   0,   0,   0,   1,   0,   0,   0,
@@ -429,13 +538,14 @@ static const ::capnp::_::AlignedData<34> b_93a6e8640a620cdc = {
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     13,   0,   0,   0,  50,   0,   0,   0,
+     13,   0,   0,   0,  74,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-      8,   0,   0,   0,   3,   0,   1,   0,
-     20,   0,   0,   0,   2,   0,   1,   0,
-    116,  97,  98, 108, 101,   0,   0,   0,
+     12,   0,   0,   0,   3,   0,   1,   0,
+     24,   0,   0,   0,   2,   0,   1,   0,
+    114, 101, 115, 112, 111, 110, 115, 101,
+      0,   0,   0,   0,   0,   0,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
-    229,  89, 100,  76, 194,  40, 112, 209,
+    183, 176, 218, 107,  82,  59, 239, 207,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
@@ -445,12 +555,12 @@ static const ::capnp::_::AlignedData<34> b_93a6e8640a620cdc = {
 ::capnp::word const* const bp_93a6e8640a620cdc = b_93a6e8640a620cdc.words;
 #if !CAPNP_LITE
 static const ::capnp::_::RawSchema* const d_93a6e8640a620cdc[] = {
-  &s_d17028c24c6459e5,
+  &s_cfef3b526bdab0b7,
 };
 static const uint16_t m_93a6e8640a620cdc[] = {0};
 static const uint16_t i_93a6e8640a620cdc[] = {0};
 const ::capnp::_::RawSchema s_93a6e8640a620cdc = {
-  0x93a6e8640a620cdc, b_93a6e8640a620cdc.words, 34, d_93a6e8640a620cdc, m_93a6e8640a620cdc,
+  0x93a6e8640a620cdc, b_93a6e8640a620cdc.words, 35, d_93a6e8640a620cdc, m_93a6e8640a620cdc,
   1, 1, i_93a6e8640a620cdc, nullptr, nullptr, { &s_93a6e8640a620cdc, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
@@ -600,6 +710,22 @@ constexpr uint16_t RPCServer::Table::Cell::Data::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind RPCServer::Table::Cell::Data::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* RPCServer::Table::Cell::Data::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// RPCServer::Response
+constexpr uint16_t RPCServer::Response::_capnpPrivate::dataWordSize;
+constexpr uint16_t RPCServer::Response::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind RPCServer::Response::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* RPCServer::Response::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// RPCServer::Response::Data
+constexpr uint16_t RPCServer::Response::Data::_capnpPrivate::dataWordSize;
+constexpr uint16_t RPCServer::Response::Data::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind RPCServer::Response::Data::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* RPCServer::Response::Data::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 // RPCServer::SendQueryParams

--- a/src/Server/generated/ServerDBMS.capnp.h
+++ b/src/Server/generated/ServerDBMS.capnp.h
@@ -22,6 +22,8 @@ CAPNP_DECLARE_SCHEMA(d17028c24c6459e5);
 CAPNP_DECLARE_SCHEMA(bd0ce84a55a2c476);
 CAPNP_DECLARE_SCHEMA(ef966708bacf4431);
 CAPNP_DECLARE_SCHEMA(aa2ac7c0d0ba789d);
+CAPNP_DECLARE_SCHEMA(cfef3b526bdab0b7);
+CAPNP_DECLARE_SCHEMA(d39793d037b602ba);
 CAPNP_DECLARE_SCHEMA(cf47b13c99e9bcb5);
 CAPNP_DECLARE_SCHEMA(93a6e8640a620cdc);
 CAPNP_DECLARE_SCHEMA(bc2c94dd270bebbd);
@@ -40,6 +42,7 @@ struct RPCServer {
 #endif  // !CAPNP_LITE
 
   struct Table;
+  struct Response;
   struct SendQueryParams;
   struct SendQueryResults;
   struct ConnectParams;
@@ -117,6 +120,41 @@ struct RPCServer::Table::Cell::Data {
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(aa2ac7c0d0ba789d, 2, 1)
+    #if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() { return &schema->defaultBrand; }
+    #endif  // !CAPNP_LITE
+  };
+};
+
+struct RPCServer::Response {
+  Response() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+  struct Data;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(cfef3b526bdab0b7, 1, 1)
+    #if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() { return &schema->defaultBrand; }
+    #endif  // !CAPNP_LITE
+  };
+};
+
+struct RPCServer::Response::Data {
+  Data() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+  enum Which: uint16_t {
+    VOID,
+    TABLE,
+  };
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(d39793d037b602ba, 1, 1)
     #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() { return &schema->defaultBrand; }
     #endif  // !CAPNP_LITE
@@ -616,6 +654,175 @@ private:
 };
 #endif  // !CAPNP_LITE
 
+class RPCServer::Response::Reader {
+public:
+  typedef Response Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base): _reader(base) {}
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline typename Data::Reader getData() const;
+
+private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class RPCServer::Response::Builder {
+public:
+  typedef Response Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {}
+  inline explicit Builder(::capnp::_::StructBuilder base): _builder(base) {}
+  inline operator Reader() const { return Reader(_builder.asReader()); }
+  inline Reader asReader() const { return *this; }
+
+  inline ::capnp::MessageSize totalSize() const { return asReader().totalSize(); }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const { return asReader().toString(); }
+#endif  // !CAPNP_LITE
+
+  inline typename Data::Builder getData();
+  inline typename Data::Builder initData();
+
+private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class RPCServer::Response::Pipeline {
+public:
+  typedef Response Pipelines;
+
+  inline Pipeline(decltype(nullptr)): _typeless(nullptr) {}
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {}
+
+  inline typename Data::Pipeline getData();
+private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class RPCServer::Response::Data::Reader {
+public:
+  typedef Data Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base): _reader(base) {}
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline Which which() const;
+  inline bool isVoid() const;
+  inline  ::capnp::Void getVoid() const;
+
+  inline bool isTable() const;
+  inline bool hasTable() const;
+  inline  ::RPCServer::Table::Reader getTable() const;
+
+private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class RPCServer::Response::Data::Builder {
+public:
+  typedef Data Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {}
+  inline explicit Builder(::capnp::_::StructBuilder base): _builder(base) {}
+  inline operator Reader() const { return Reader(_builder.asReader()); }
+  inline Reader asReader() const { return *this; }
+
+  inline ::capnp::MessageSize totalSize() const { return asReader().totalSize(); }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const { return asReader().toString(); }
+#endif  // !CAPNP_LITE
+
+  inline Which which();
+  inline bool isVoid();
+  inline  ::capnp::Void getVoid();
+  inline void setVoid( ::capnp::Void value = ::capnp::VOID);
+
+  inline bool isTable();
+  inline bool hasTable();
+  inline  ::RPCServer::Table::Builder getTable();
+  inline void setTable( ::RPCServer::Table::Reader value);
+  inline  ::RPCServer::Table::Builder initTable();
+  inline void adoptTable(::capnp::Orphan< ::RPCServer::Table>&& value);
+  inline ::capnp::Orphan< ::RPCServer::Table> disownTable();
+
+private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class RPCServer::Response::Data::Pipeline {
+public:
+  typedef Data Pipelines;
+
+  inline Pipeline(decltype(nullptr)): _typeless(nullptr) {}
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {}
+
+private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
 class RPCServer::SendQueryParams::Reader {
 public:
   typedef SendQueryParams Reads;
@@ -714,8 +921,8 @@ public:
   }
 #endif  // !CAPNP_LITE
 
-  inline bool hasTable() const;
-  inline  ::RPCServer::Table::Reader getTable() const;
+  inline bool hasResponse() const;
+  inline  ::RPCServer::Response::Reader getResponse() const;
 
 private:
   ::capnp::_::StructReader _reader;
@@ -745,12 +952,12 @@ public:
   inline ::kj::StringTree toString() const { return asReader().toString(); }
 #endif  // !CAPNP_LITE
 
-  inline bool hasTable();
-  inline  ::RPCServer::Table::Builder getTable();
-  inline void setTable( ::RPCServer::Table::Reader value);
-  inline  ::RPCServer::Table::Builder initTable();
-  inline void adoptTable(::capnp::Orphan< ::RPCServer::Table>&& value);
-  inline ::capnp::Orphan< ::RPCServer::Table> disownTable();
+  inline bool hasResponse();
+  inline  ::RPCServer::Response::Builder getResponse();
+  inline void setResponse( ::RPCServer::Response::Reader value);
+  inline  ::RPCServer::Response::Builder initResponse();
+  inline void adoptResponse(::capnp::Orphan< ::RPCServer::Response>&& value);
+  inline ::capnp::Orphan< ::RPCServer::Response> disownResponse();
 
 private:
   ::capnp::_::StructBuilder _builder;
@@ -770,7 +977,7 @@ public:
   inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
       : _typeless(kj::mv(typeless)) {}
 
-  inline  ::RPCServer::Table::Pipeline getTable();
+  inline  ::RPCServer::Response::Pipeline getResponse();
 private:
   ::capnp::AnyPointer::Pipeline _typeless;
   friend class ::capnp::PipelineHook;
@@ -1277,6 +1484,111 @@ inline ::capnp::Orphan< ::capnp::Text> RPCServer::Table::Cell::Data::Builder::di
       ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
+inline typename RPCServer::Response::Data::Reader RPCServer::Response::Reader::getData() const {
+  return typename RPCServer::Response::Data::Reader(_reader);
+}
+inline typename RPCServer::Response::Data::Builder RPCServer::Response::Builder::getData() {
+  return typename RPCServer::Response::Data::Builder(_builder);
+}
+#if !CAPNP_LITE
+inline typename RPCServer::Response::Data::Pipeline RPCServer::Response::Pipeline::getData() {
+  return typename RPCServer::Response::Data::Pipeline(_typeless.noop());
+}
+#endif  // !CAPNP_LITE
+inline typename RPCServer::Response::Data::Builder RPCServer::Response::Builder::initData() {
+  _builder.setDataField< ::uint16_t>(::capnp::bounded<0>() * ::capnp::ELEMENTS, 0);
+  _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS).clear();
+  return typename RPCServer::Response::Data::Builder(_builder);
+}
+inline  ::RPCServer::Response::Data::Which RPCServer::Response::Data::Reader::which() const {
+  return _reader.getDataField<Which>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+inline  ::RPCServer::Response::Data::Which RPCServer::Response::Data::Builder::which() {
+  return _builder.getDataField<Which>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+
+inline bool RPCServer::Response::Data::Reader::isVoid() const {
+  return which() == RPCServer::Response::Data::VOID;
+}
+inline bool RPCServer::Response::Data::Builder::isVoid() {
+  return which() == RPCServer::Response::Data::VOID;
+}
+inline  ::capnp::Void RPCServer::Response::Data::Reader::getVoid() const {
+  KJ_IREQUIRE((which() == RPCServer::Response::Data::VOID),
+              "Must check which() before get()ing a union member.");
+  return _reader.getDataField< ::capnp::Void>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+
+inline  ::capnp::Void RPCServer::Response::Data::Builder::getVoid() {
+  KJ_IREQUIRE((which() == RPCServer::Response::Data::VOID),
+              "Must check which() before get()ing a union member.");
+  return _builder.getDataField< ::capnp::Void>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+inline void RPCServer::Response::Data::Builder::setVoid( ::capnp::Void value) {
+  _builder.setDataField<RPCServer::Response::Data::Which>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, RPCServer::Response::Data::VOID);
+  _builder.setDataField< ::capnp::Void>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
+}
+
+inline bool RPCServer::Response::Data::Reader::isTable() const {
+  return which() == RPCServer::Response::Data::TABLE;
+}
+inline bool RPCServer::Response::Data::Builder::isTable() {
+  return which() == RPCServer::Response::Data::TABLE;
+}
+inline bool RPCServer::Response::Data::Reader::hasTable() const {
+  if (which() != RPCServer::Response::Data::TABLE) return false;
+  return !_reader.getPointerField(
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
+}
+inline bool RPCServer::Response::Data::Builder::hasTable() {
+  if (which() != RPCServer::Response::Data::TABLE) return false;
+  return !_builder.getPointerField(
+      ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
+}
+inline  ::RPCServer::Table::Reader RPCServer::Response::Data::Reader::getTable() const {
+  KJ_IREQUIRE((which() == RPCServer::Response::Data::TABLE),
+              "Must check which() before get()ing a union member.");
+  return ::capnp::_::PointerHelpers< ::RPCServer::Table>::get(_reader.getPointerField(
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline  ::RPCServer::Table::Builder RPCServer::Response::Data::Builder::getTable() {
+  KJ_IREQUIRE((which() == RPCServer::Response::Data::TABLE),
+              "Must check which() before get()ing a union member.");
+  return ::capnp::_::PointerHelpers< ::RPCServer::Table>::get(_builder.getPointerField(
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void RPCServer::Response::Data::Builder::setTable( ::RPCServer::Table::Reader value) {
+  _builder.setDataField<RPCServer::Response::Data::Which>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, RPCServer::Response::Data::TABLE);
+  ::capnp::_::PointerHelpers< ::RPCServer::Table>::set(_builder.getPointerField(
+      ::capnp::bounded<0>() * ::capnp::POINTERS), value);
+}
+inline  ::RPCServer::Table::Builder RPCServer::Response::Data::Builder::initTable() {
+  _builder.setDataField<RPCServer::Response::Data::Which>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, RPCServer::Response::Data::TABLE);
+  return ::capnp::_::PointerHelpers< ::RPCServer::Table>::init(_builder.getPointerField(
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void RPCServer::Response::Data::Builder::adoptTable(
+    ::capnp::Orphan< ::RPCServer::Table>&& value) {
+  _builder.setDataField<RPCServer::Response::Data::Which>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, RPCServer::Response::Data::TABLE);
+  ::capnp::_::PointerHelpers< ::RPCServer::Table>::adopt(_builder.getPointerField(
+      ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
+}
+inline ::capnp::Orphan< ::RPCServer::Table> RPCServer::Response::Data::Builder::disownTable() {
+  KJ_IREQUIRE((which() == RPCServer::Response::Data::TABLE),
+              "Must check which() before get()ing a union member.");
+  return ::capnp::_::PointerHelpers< ::RPCServer::Table>::disown(_builder.getPointerField(
+      ::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
 inline bool RPCServer::SendQueryParams::Reader::hasQuery() const {
   return !_reader.getPointerField(
       ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
@@ -1311,42 +1623,42 @@ inline ::capnp::Orphan< ::capnp::Text> RPCServer::SendQueryParams::Builder::diso
       ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
-inline bool RPCServer::SendQueryResults::Reader::hasTable() const {
+inline bool RPCServer::SendQueryResults::Reader::hasResponse() const {
   return !_reader.getPointerField(
       ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
-inline bool RPCServer::SendQueryResults::Builder::hasTable() {
+inline bool RPCServer::SendQueryResults::Builder::hasResponse() {
   return !_builder.getPointerField(
       ::capnp::bounded<0>() * ::capnp::POINTERS).isNull();
 }
-inline  ::RPCServer::Table::Reader RPCServer::SendQueryResults::Reader::getTable() const {
-  return ::capnp::_::PointerHelpers< ::RPCServer::Table>::get(_reader.getPointerField(
+inline  ::RPCServer::Response::Reader RPCServer::SendQueryResults::Reader::getResponse() const {
+  return ::capnp::_::PointerHelpers< ::RPCServer::Response>::get(_reader.getPointerField(
       ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
-inline  ::RPCServer::Table::Builder RPCServer::SendQueryResults::Builder::getTable() {
-  return ::capnp::_::PointerHelpers< ::RPCServer::Table>::get(_builder.getPointerField(
+inline  ::RPCServer::Response::Builder RPCServer::SendQueryResults::Builder::getResponse() {
+  return ::capnp::_::PointerHelpers< ::RPCServer::Response>::get(_builder.getPointerField(
       ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
-inline  ::RPCServer::Table::Pipeline RPCServer::SendQueryResults::Pipeline::getTable() {
-  return  ::RPCServer::Table::Pipeline(_typeless.getPointerField(0));
+inline  ::RPCServer::Response::Pipeline RPCServer::SendQueryResults::Pipeline::getResponse() {
+  return  ::RPCServer::Response::Pipeline(_typeless.getPointerField(0));
 }
 #endif  // !CAPNP_LITE
-inline void RPCServer::SendQueryResults::Builder::setTable( ::RPCServer::Table::Reader value) {
-  ::capnp::_::PointerHelpers< ::RPCServer::Table>::set(_builder.getPointerField(
+inline void RPCServer::SendQueryResults::Builder::setResponse( ::RPCServer::Response::Reader value) {
+  ::capnp::_::PointerHelpers< ::RPCServer::Response>::set(_builder.getPointerField(
       ::capnp::bounded<0>() * ::capnp::POINTERS), value);
 }
-inline  ::RPCServer::Table::Builder RPCServer::SendQueryResults::Builder::initTable() {
-  return ::capnp::_::PointerHelpers< ::RPCServer::Table>::init(_builder.getPointerField(
+inline  ::RPCServer::Response::Builder RPCServer::SendQueryResults::Builder::initResponse() {
+  return ::capnp::_::PointerHelpers< ::RPCServer::Response>::init(_builder.getPointerField(
       ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
-inline void RPCServer::SendQueryResults::Builder::adoptTable(
-    ::capnp::Orphan< ::RPCServer::Table>&& value) {
-  ::capnp::_::PointerHelpers< ::RPCServer::Table>::adopt(_builder.getPointerField(
+inline void RPCServer::SendQueryResults::Builder::adoptResponse(
+    ::capnp::Orphan< ::RPCServer::Response>&& value) {
+  ::capnp::_::PointerHelpers< ::RPCServer::Response>::adopt(_builder.getPointerField(
       ::capnp::bounded<0>() * ::capnp::POINTERS), kj::mv(value));
 }
-inline ::capnp::Orphan< ::RPCServer::Table> RPCServer::SendQueryResults::Builder::disownTable() {
-  return ::capnp::_::PointerHelpers< ::RPCServer::Table>::disown(_builder.getPointerField(
+inline ::capnp::Orphan< ::RPCServer::Response> RPCServer::SendQueryResults::Builder::disownResponse() {
+  return ::capnp::_::PointerHelpers< ::RPCServer::Response>::disown(_builder.getPointerField(
       ::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 

--- a/src/View/Client/Client.cpp
+++ b/src/View/Client/Client.cpp
@@ -48,16 +48,16 @@ void Client::connect () {
     }
 }
 
-kj::Own <Table> Client::sendQuery (std::string const & query) {
+Response Client::sendQuery (std::string const & query) {
     // Set up the request
     auto request = client->sendQueryRequest ();
     request.setQuery (query);
 
     // Send the request and wait for the result
-    return Wrapper::unwrapTable (request.send().wait (waitScope).getTable());
+    return Wrapper::unwrapResponse (request.send().wait (waitScope).getResponse());
 }
 
-void Client::startInterface (std::function <void (Table const &)> const & action) {
+void Client::startInterface (std::function <void (Response)> const & action) {
     connect();
 
     std::string query;
@@ -76,7 +76,7 @@ void Client::startInterface (std::function <void (Table const &)> const & action
         if (query == "exit") return;
 
         try {
-            action (* sendQuery (query));
+            action (sendQuery (query));
         } catch (std::exception & e) {
             std::cout << "Server: '" << e.what() << "'" << std::endl;
         }

--- a/src/View/Client/Client.h
+++ b/src/View/Client/Client.h
@@ -28,9 +28,9 @@ public:
     explicit Client (std::string const & address);
 
     void connect ();
-    kj::Own <Table> sendQuery (std::string const & query);
+    Response sendQuery (std::string const & query);
 
-    void startInterface (std::function <void (Table const &)> const & action);
+    void startInterface (std::function <void (Response)> const & action);
 };
 
 

--- a/src/config.h
+++ b/src/config.h
@@ -4,9 +4,17 @@
 /// Minimum LOG level. 0 = Everything, 1 = Ignore LOG (INFO), ...
 #define GOOGLE_STRIP_LOG 0
 
-#define THROW(error)                \
+#ifdef ERRORS_AS_WARNINGS
+#define THROW(error) {              \
+    LOG (WARNING) << error.what();  \
+    throw error;                    \
+}; true
+#else
+#define THROW(error) {              \
     LOG (ERROR) << error.what();    \
-    throw error
+    throw error;                    \
+}; true
+#endif
 
 #include <string>
 #include <cstdlib>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@ int main (int argc, char * argv[]) {
     std::cout << "Connecting to '" << address << ((argc > 1) ? "" : STR+ ":" + std::to_string (port)) << "'..." << std::endl;
 
     Client client = (argc > 1) ? Client (address) : Client (address, port);
-    client.startInterface([] (Table const & t) { std::cout << t; });
+    client.startInterface([] (Response r) { std::cout << r; });
 
     LOG (INFO) << "Stop Running";
 }

--- a/test/DBMS/DBMS.cpp
+++ b/test/DBMS/DBMS.cpp
@@ -18,6 +18,24 @@ SCENARIO ("Issuing a query returns a valid Table") {
                 "DATABASES()",
         };
         for (auto const & query : queries) {
+            (std::cout << "Current Query: " << query).flush();
+
+            std::string despacedQuery = Parser::despace (query);
+
+            (std::cout << '.').flush();
+
+            std::string enrichedQuery = Parser::enrich (despacedQuery);
+
+            (std::cout << '.').flush();
+
+            kj::Own <ParseTree> tokenisedQuery = Parser::tokeniseQuery (enrichedQuery);
+
+            (std::cout << '.').flush();
+
+//            kj::Own <Query> procQuery = Parser::buildQuery (tokenisedQuery);
+
+            std::cout << "\tDone" << std::endl;
+
 //            REQUIRE_NOTHROW (Parser::parseQuery (query));
 //            CHECK_NOTHROW (DBMS::evalQuery (query));
         }

--- a/test/DBMS/DBMS.cpp
+++ b/test/DBMS/DBMS.cpp
@@ -2,19 +2,59 @@
 #include "../../src/DBMS/DBMS.h"
 
 SCENARIO ("Issuing a query returns a valid Table") {
-    std::vector <std::string> queries {
-        "create (TestDatabase)",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-    };
-    Table table = * std::get <kj::Own <Table const>> (DBMS::evalQuery("USERS ()"));
-//    CHECK (!!table);
+    GIVEN ("Some queries") {
+        std::vector <std::string> queries {
+                "CREATE(ParserTestDB)",
+                "DELETE(ParserTestDB)",
+                "CREATE(ParserTestDB)",
+                "ParserTestDB.CREATE(@root)",
+                "ParserTestDB.@root.GIVE()",
+                "ParserTestDB.DELETE(@root)",
+                "ParserTestDB.CREATE(#table, [name, surname, age])",
+                "ParserTestDB.#table.READ ([name], [{age : 10}])",
+                "ParserTestDB.#root.INSERT([{name : Dee}, {surname : John}, {age : 10}])",
+                "ParserTestDB.DELETE(#root)",
+                "USERS()",
+                "DATABASES()",
+        };
+        for (auto const & query : queries) {
+//            REQUIRE_NOTHROW (Parser::parseQuery (query));
+//            CHECK_NOTHROW (DBMS::evalQuery (query));
+        }
+    }
+
+    GIVEN ("Some queries with return type") {
+        std::vector <std::pair <std::string, ResponseType>> queries {
+                {"create (TestDatabase)", VOID},
+                {"", VOID},
+                {"", VOID},
+                {"", VOID},
+                {"", VOID},
+                {"", VOID},
+                {"", VOID},
+                {"", VOID},
+                {"", VOID},
+        };
+        Response response;
+        for (auto const & query : queries) {
+            WHEN ("I evaluate a query with supposed return type " << ((query.second) ? "TABLE" : "NULL")) {
+                CHECK_NOTHROW (response = DBMS::evalQuery (query.first));
+                switch (query.second) {
+                    case ResponseType::VOID:
+                        THEN ("I get a NULL response") {
+//                            CHECK (!response.index ());
+                        }
+                        break;
+                    case ResponseType::TABLE:
+                        THEN ("I get a valid Table as response") {
+                            CHECK (!! * std::get <kj::Own <Table const>> (response));
+                        }
+                    default:
+                        LOG (FATAL) << "ResponseType has gone insane";
+                }
+            }
+        }
+    }
 }
 
 /* Copyright (C) 2020 Aaron Alef & Felix Bachstein */

--- a/test/DBMS/DBMS.cpp
+++ b/test/DBMS/DBMS.cpp
@@ -11,33 +11,15 @@ SCENARIO ("Issuing a query returns a valid Table") {
                 "ParserTestDB.@root.GIVE()",
                 "ParserTestDB.DELETE(@root)",
                 "ParserTestDB.CREATE(#table, [name, surname, age])",
-                "ParserTestDB.#table.READ ([name], [{age : 10}])",
+                "ParserTestDB.#table.READ ([name],[{surname:John},{age:10}])",
                 "ParserTestDB.#root.INSERT([{name : Dee}, {surname : John}, {age : 10}])",
                 "ParserTestDB.DELETE(#root)",
                 "USERS()",
                 "DATABASES()",
         };
         for (auto const & query : queries) {
-            (std::cout << "Current Query: " << query).flush();
-
-            std::string despacedQuery = Parser::despace (query);
-
-            (std::cout << '.').flush();
-
-            std::string enrichedQuery = Parser::enrich (despacedQuery);
-
-            (std::cout << '.').flush();
-
-            kj::Own <ParseTree> tokenisedQuery = Parser::tokeniseQuery (enrichedQuery);
-
-            (std::cout << '.').flush();
-
-            kj::Own <Query> procQuery = Parser::buildQuery (tokenisedQuery);
-
-            std::cout << "\tDone" << std::endl;
-
-//            REQUIRE_NOTHROW (Parser::parseQuery (query));
-//            CHECK_NOTHROW (DBMS::evalQuery (query));
+            REQUIRE_NOTHROW (Parser::parseQuery (query));
+            CHECK_NOTHROW (DBMS::evalQuery (query));
         }
     }
 

--- a/test/DBMS/DBMS.cpp
+++ b/test/DBMS/DBMS.cpp
@@ -32,7 +32,7 @@ SCENARIO ("Issuing a query returns a valid Table") {
 
             (std::cout << '.').flush();
 
-//            kj::Own <Query> procQuery = Parser::buildQuery (tokenisedQuery);
+            kj::Own <Query> procQuery = Parser::buildQuery (tokenisedQuery);
 
             std::cout << "\tDone" << std::endl;
 

--- a/test/DBMS/DBMS.cpp
+++ b/test/DBMS/DBMS.cpp
@@ -13,7 +13,7 @@ SCENARIO ("Issuing a query returns a valid Table") {
         "",
         "",
     };
-    Table table = * DBMS::evalQuery("USERS ()");
+    Table table = * std::get <kj::Own <Table const>> (DBMS::evalQuery("USERS ()"));
 //    CHECK (!!table);
 }
 

--- a/test/Language/Parser/Parser.cpp
+++ b/test/Language/Parser/Parser.cpp
@@ -2,7 +2,7 @@
 #include "../../../src/Language/Parser/Parser.h"
 
 SCENARIO ("I can convert strings into meaningful Query structs (or errors)") {
-    GIVEN ("Some correct queries") {
+    GIVEN ("Queries at each step of parsing") {
         std::vector <std::string> queries {
                 "cReAtE (ParserTestDB)\n",
                 "  delete        (  ParserTestDB  )    ",
@@ -103,23 +103,24 @@ SCENARIO ("I can convert strings into meaningful Query structs (or errors)") {
             CHECK_THROWS_AS (Parser::parseQuery (invalidQuery), std::logic_error);
         }
     }
-    std::vector <std::string> queries {
-            "CREATE(ParserTestDB)",
-            "DELETE(ParserTestDB)",
-            "CREATE(ParserTestDB)",
-            "ParserTestDB.CREATE(@root)",
-            "ParserTestDB.@root.GIVE()",
-            "ParserTestDB.DELETE(@root)",
-            "ParserTestDB.CREATE(#root, [name, surname, age])",
-            "ParserTestDB.#root.INSERT([{name : Dee}, {surname : John}, {age : 10}])",
-            "ParserTestDB.DELETE(#root)",
-            "USERS()",
-            "DATABASES()",
-    };
-
-    for (auto const & query : queries) {
-        kj::Own <Query> queryResult;
-        CHECK_NOTHROW (queryResult = Parser::parseQuery (query));
+    GIVEN ("Some valid queries to parse") {
+        std::vector <std::string> queries {
+                "CREATE(ParserTestDB)",
+                "DELETE(ParserTestDB)",
+                "CREATE(ParserTestDB)",
+                "ParserTestDB.CREATE(@root)",
+                "ParserTestDB.@root.GIVE()",
+                "ParserTestDB.DELETE(@root)",
+                "ParserTestDB.CREATE(#table, [name, surname, age])",
+                "ParserTestDB.#table.READ ([name], [{age : 10}])",
+                "ParserTestDB.#root.INSERT([{name : Dee}, {surname : John}, {age : 10}])",
+                "ParserTestDB.DELETE(#root)",
+                "USERS()",
+                "DATABASES()",
+        };
+        for (auto const & query : queries) {
+//            CHECK_NOTHROW (Parser::parseQuery (query));
+        }
     }
 }
 

--- a/test/Time/Time.cpp
+++ b/test/Time/Time.cpp
@@ -10,12 +10,24 @@ unsigned long fibonacci (unsigned long n) {
 TEST_CASE ("I can benchmark single function calls") {
     GIVEN ("A function and some parameters") {
         unsigned long test;
-        LOG_TIME (test = fibonacci (25));
-        CHECK (test > 100);
-        CHECK (test < 100000);
-        test = TIME (fibonacci (25)).count();
-        CHECK (test > 100);
-        CHECK (test < 100000);
+
+        WHEN ("I log calculating the 25th Fibonacci number recursively") {
+            LOG_TIME (test = fibonacci (25));
+
+            THEN ("It takes a few milliseconds to execute") {
+                CHECK (test > 100);
+                CHECK (test < 100000);
+            }
+        }
+
+        WHEN ("I calculate the 25th Fibonacci number recursively") {
+            test = TIME (fibonacci (25)).count();
+
+            THEN ("It takes a few milliseconds to execute") {
+                CHECK (test > 100);
+                CHECK (test < 100000);
+            }
+        }
     }
 }
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -2,7 +2,7 @@
 export GLOG_stderrtreshold="$1"
 export GLOG_minloglevel="$1"
 export SCRATCHQL_ROOT=$PWD
-cmake --build cmake-build-debug --target Test > /dev/zero #2> /dev/zero
+cmake --build cmake-build-debug --target Test
 result=$?
 if test $result -ne 0
 then echo "Building failed!"


### PR DESCRIPTION
`Response` is implemented as
`std::variant <std::monostate, kj::Own <Table const>`
Since "Setter" queries won't have return values, this should ease the
network load