### PR TITLE
feat(server): make the project run as either server, client or both

### DIFF
--- a/client
+++ b/client
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Builds the project and runs the client
+# The client tries to connect to "localhost:PORT" where PORT is defined in config.h
+# Otherwise, a specific address and port may be given as follows:
+#
+#         Syntax:  ```./client ADDRESS:PORT```
+#         Example: ```./client 127.0.0.1:12345```
+#
+
+if test "$1" == "--license"
+then cat LICENSE | less
+exit
+fi
+
+export SCRATCHQL_ROOT=$PWD
+
+mkdir -p cmake-build-debug
+cmake --build cmake-build-debug --target Database > /dev/zero
+result=$?
+
+if test $result -ne 0
+then echo "Build failed!"
+exit $result
+fi
+
+cmd="./cmake-build-debug/Database --client"
+
+if test $# -ne 0
+then
+  cmd="$cmd $1"
+fi
+$cmd

--- a/server
+++ b/server
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Builds the project and runs the server
+# The server tries to run on port PORT which is defined in config.h
+# On default, it listens to all addresses.
+# Otherwise, a specific address and port may be given as follows:
+#
+#         Syntax:  ```./server ADDRESS:PORT```
+#         Example: ```./server 127.0.0.1:12345```
+#
+
+if test "$1" == "--license"
+then cat LICENSE | less
+exit
+fi
+
+export SCRATCHQL_ROOT=$PWD
+
+mkdir -p cmake-build-debug
+cmake --build cmake-build-debug --target Database > /dev/zero
+result=$?
+
+if test $result -ne 0
+then echo "Build failed!"
+exit $result
+fi
+
+cmd="./cmake-build-debug/Database --server"
+
+if test $# -ne 0
+then
+  cmd="$cmd $1"
+fi
+$cmd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,10 @@ int main (int argc, char * argv[]) {
     std::cout << "Setting database up on '" << address << ((argc > 1) ? "" :
     STR+ ":" + std::to_string (port)) << "'..." << std::endl;
 
-    kj::NEVER_DONE.wait (server.getWaitScope ());
+    std::cout << "Connecting to '" << address << ((argc > 1) ? "" : STR+ ":" + std::to_string (port)) << "'..." << std::endl;
+
+    Client client = (argc > 1) ? Client (address) : Client (address, port);
+    client.startInterface([] (Response r) { std::cout << r; });
 
     LOG (INFO) << "Stop Running";
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,19 +19,48 @@
 #include "main.h"
 
 int main (int argc, char * argv[]) {
-    google::InitGoogleLogging(argv [0]);
+    google::InitGoogleLogging (argv[0]);
 
     LOG (INFO) << "Start Running";
     LOG (INFO) << PROJECT_ROOT;
 
+    std::string address (argc > 2 ? argv[2] : STR+ "*:" + std::to_string (PORT));
+    auto execServer = [] (std::string const & address, bool never_done = false) -> capnp::EzRpcServer const & {
+        (std::cout << "Setting database up on '" << address << "'...").flush();
+        capnp::EzRpcServer server (kj::heap <DatabaseImpl <DBMS>> (), address);
+        server.getPort().wait (server.getWaitScope());
+        std::cout << " Done" << std::endl;
 
-    std::string address ((argc > 1) ? argv [1] : "*");
-    capnp::EzRpcServer server (kj::heap <DatabaseImpl <DBMS>> (), address);
-    uint port = server.getPort().wait (server.getWaitScope());
-    std::cout << "Setting database up on '" << address << ((argc > 1) ? "" :
-    STR+ ":" + std::to_string (port)) << "'..." << std::endl;
+        if (never_done) kj::NEVER_DONE.wait (server.getWaitScope ());
+        return std::move (server);
+    };
 
-    kj::NEVER_DONE.wait (server.getWaitScope());
+    auto execClient = [] (std::string const & address, int port = -1) {
+        Client client = (port < 0) ? Client (address) : Client (address, port);
+        client.startInterface ([] (Response r) {std::cout << r;});
+    };
+
+    if (argc == 1) {
+        auto const & server = execServer (address);
+        execClient (ADDRESS, PORT);
+    } else {
+        std::string param (argv [1]);
+        if (param == "--server") {
+            auto const & server = execServer (address, true);
+        }
+        else if (param == "--client") {
+            if (argc > 2) {
+                execClient (address);
+            } else {
+                execClient (ADDRESS, PORT);
+            }
+        }
+        else {
+            std::cerr << "Unknown parameters: " << param << std::endl;
+            std::cerr << "Syntax: " << argv [0] << " (--server|--client) (address:port)";
+            return EXIT_FAILURE;
+        }
+    }
 
     LOG (INFO) << "Stop Running";
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,10 +31,7 @@ int main (int argc, char * argv[]) {
     std::cout << "Setting database up on '" << address << ((argc > 1) ? "" :
     STR+ ":" + std::to_string (port)) << "'..." << std::endl;
 
-    std::cout << "Connecting to '" << address << ((argc > 1) ? "" : STR+ ":" + std::to_string (port)) << "'..." << std::endl;
-
-    Client client = (argc > 1) ? Client (address) : Client (address, port);
-    client.startInterface([] (Response r) { std::cout << r; });
+    kj::NEVER_DONE.wait (server.getWaitScope ());
 
     LOG (INFO) << "Stop Running";
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,10 +31,7 @@ int main (int argc, char * argv[]) {
     std::cout << "Setting database up on '" << address << ((argc > 1) ? "" :
     STR+ ":" + std::to_string (port)) << "'..." << std::endl;
 
-    std::cout << "Connecting to '" << address << ((argc > 1) ? "" : STR+ ":" + std::to_string (port)) << "'..." << std::endl;
-
-    Client client = (argc > 1) ? Client (address) : Client (address, port);
-    client.startInterface([] (Response r) { std::cout << r; });
+    kj::NEVER_DONE.wait (server.getWaitScope());
 
     LOG (INFO) << "Stop Running";
 }


### PR DESCRIPTION
Adds two bash scripts, `client` and `server` which take an optional parameter, "address:port", to specify the target address with port.

Also, `--license` prints the LICENSE file